### PR TITLE
Allow exclude dilutions in RachelStyle2019 assays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,19 @@
+=========
+Changelog
+=========
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
+
+0.2.dev0
+-----------
+
+Added
+++++++
+- Allow exclusion of specific dilutions from *RachelStyle2019* neutralization assays.
+
+0.1.0
+---------------------------
+Initial release
+

--- a/docs/example_data/rachelstyle2019_config.yaml
+++ b/docs/example_data/rachelstyle2019_config.yaml
@@ -16,6 +16,7 @@
         virus: wt
         dilution_factor: 3
         initial_concentration: 0.00926
+        excluded_dilutions: [5, 6]
       19:
         serum: HC140010
         virus: wt

--- a/docs/rachelstyle2019_example.rst
+++ b/docs/rachelstyle2019_example.rst
@@ -94,10 +94,13 @@ the docs for that function, for each Excel file we need:
 -  *sheet_mapping*: a dictionary keyed be the name of each sheet in
    *excelfile* which in turn specifies:
 
-   -  ‘serum’: name of serum
-   -  ‘virus’: name of virus
-   -  ‘initial_concentration’: highest concentration of serum
-   -  ‘dilution_factor’: dilution factor in serial dilutions of serum
+   - *serum*: name of serum
+   - *virus*: name of virus
+   - *initial_concentration*: highest concentration of serum
+   - *dilution_factor*: dilution factor in serial dilutions of serum
+   - *excluded_dilutions* (optional): list of dilutions to exclude, with
+     1 being the least dilute and 12 being the most dilute. Useful if some
+     columns in the plate have a known problem (for instance, edge effects).
 
 You can specify this information in a `YAML
 format <https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html>`__
@@ -142,6 +145,7 @@ Here are the contents of the YAML configuration file.
             virus: wt
             dilution_factor: 3
             initial_concentration: 0.00926
+            excluded_dilutions: [5, 6]
           19:
             serum: HC140010
             virus: wt
@@ -174,6 +178,10 @@ case, there is only one), and then gives the name of the Excel file
 (*sheet_mapping*). Therefore, the dictionary for each experiment can be
 directly passed to :func:`neutcurve.parse_excel.parseRachelStyle2019`
 as `**kwargs`.
+
+Note how to illustrate the *excluded_dilutions* option, we have excluded
+two columns from serum *HC060106*. In the plots below, you can see how
+the data points for those columns will be missing.
 
 We also need to specify the output directory where the results are
 written:
@@ -294,7 +302,7 @@ the IC50s:
           serum virus replicate  nreplicates     ic50    ic50_bound  ic50_str  midpoint  slope  top  bottom
     0  HC080048    wt   average            3   0.0016  interpolated    0.0016    0.0016   2.71    1       0
     1  HC080043    wt   average            3 0.000684  interpolated  0.000684  0.000684   1.35    1       0
-    2  HC060106    wt   average            3  0.00279  interpolated   0.00279   0.00279   1.16    1       0
+    2  HC060106    wt   average            3   0.0028  interpolated    0.0028    0.0028   1.23    1       0
     3  HC140010    wt   average            3  0.00262  interpolated   0.00262   0.00262   3.36    1       0
     4  HC070072    wt   average            3  0.00118  interpolated   0.00118   0.00118   1.79    1       0
     5  HC070041    wt   average            3 0.000396  interpolated  0.000396  0.000396   3.86    1       0

--- a/neutcurve/__init__.py
+++ b/neutcurve/__init__.py
@@ -16,7 +16,7 @@ and classes into the package namespace:
 
 __author__ = 'Jesse Bloom'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.1.0'
+__version__ = '0.2.dev0'
 __url__ = 'https://github.com/jbloomlab/neutcurve'
 
 from neutcurve.curvefits import CurveFits  # noqa: F401

--- a/neutcurve/parse_excel.py
+++ b/neutcurve/parse_excel.py
@@ -113,7 +113,7 @@ def _parse_BloomLab_TecanPlate(*,
     all_cols = list(range(1, ncols + 1))
     if layout == 'RachelStyle2019':
         # reverse excluded dilution columns if assay dilutes columns in reverse
-        exclude_cols = set([ncols - col + 1 for col in excluded_dilutions])
+        exclude_cols = {ncols - col + 1 for col in excluded_dilutions}
     else:
         raise ValueError(f"invalid layout of {layout}")
     if exclude_cols > set(all_cols):

--- a/neutcurve/parse_excel.py
+++ b/neutcurve/parse_excel.py
@@ -30,8 +30,12 @@ def parseRachelStyle2019(*,
               - 'serum': name of serum.
               - 'virus': name of virus.
               - 'dilution_factor': fold-dilution of serum along plate.
-              - 'initial_concentration': final serum concentration in
-                the first well used to start the dilution series.
+              - 'initial_concentration': serum concentration in first well
+                used to start dilution series.
+              - 'excluded_dilutions' (optional) : list of dilutions to
+                exclude from returned results, with 1 being least dilute
+                and 12 being most dilute. Useful if some columns
+                in plate have a known problem.
 
     Returns:
         A pandas DataFrame in the tidy format read by
@@ -58,20 +62,30 @@ def parseRachelStyle2019(*,
                          f"sheets not in `sheet_mapping`: {extra_sheets}")
 
     neutdata = []
+    req_keys = ['dilution_factor', 'initial_concentration', 'serum', 'virus']
+    optional_keys = ['excluded_dilutions']
     for sheet, sheet_info in sheet_mapping.items():
 
         if sheet not in sheet_data:
             raise ValueError(f"sheet {sheet} specified in `sheet_mapping` "
                              f"is not present in `excelfile` {excelfile}")
 
+        extra_keys = set(sheet_info.keys()) - set(req_keys + optional_keys)
+        if extra_keys:
+            raise ValueError(f"`sheet_mapping` has extra keys {extra_keys} "
+                             f"for sheet {sheet}. Allowed keys are {req_keys} "
+                             f"and optionally {optional_keys}.")
+
         kwargs = {'layout': 'RachelStyle2019'}
-        for key in ['dilution_factor', 'initial_concentration',
-                    'serum', 'virus']:
+        for key in req_keys:
             try:
                 kwargs[key] = sheet_info[key]
             except KeyError:
                 raise ValueError(f"`sheet_mapping` does not specify {key} "
                                  f"for sheet {sheet}")
+        for key in optional_keys:
+            if key in sheet_info:
+                kwargs[key] = sheet_info[key]
 
         neutdata.append(_parse_BloomLab_TecanPlate(
                 sheet_df=sheet_data[sheet],
@@ -90,22 +104,36 @@ def _parse_BloomLab_TecanPlate(*,
                                layout,
                                serum,
                                virus,
+                               excluded_dilutions=(),
                                ):
     """Process data frame for one 96-well plate of Bloom lab Tecan."""
     # expected rows / columns
     rows = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
-    cols = list(range(1, 13))
+    ncols = 12
+    all_cols = list(range(1, ncols + 1))
+    if layout == 'RachelStyle2019':
+        # reverse excluded dilution columns if assay dilutes columns in reverse
+        exclude_cols = set([ncols - col + 1 for col in excluded_dilutions])
+    else:
+        raise ValueError(f"invalid layout of {layout}")
+    if exclude_cols > set(all_cols):
+        raise ValueError('invalid col to exclude')
+    retained_cols = [col for col in all_cols if col not in exclude_cols]
+    if not retained_cols:
+        raise ValueError('no cols retained after `exclude_cols`')
 
     # check for expected rows / columns
     if sheet_df.index.tolist() != rows:
         raise ValueError(f"{sheet_name_for_err} does not have expected rows.\n"
                          f"Expected: {rows}\nGot: {sheet_df.index.tolist()}")
-    if sheet_df.columns.tolist() != cols:
+    if sheet_df.columns.tolist() != all_cols:
         raise ValueError(f"{sheet_name_for_err} does not have expected "
-                         f"columns.\nExpected: {cols}\n"
+                         f"columns.\nExpected: {all_cols}\n"
                          f"Got: {sheet_df.columns.tolist()}")
-    if not all(pd.api.types.is_numeric_dtype(sheet_df[col]) for col in cols):
+    if not all(pd.api.types.is_numeric_dtype(sheet_df[c]) for c in all_cols):
         raise ValueError(f"Entries in {sheet_name_for_err} not all numerical")
+
+    sheet_df = sheet_df[retained_cols]
 
     if layout == 'RachelStyle2019':
         reps = {rep: sheet_df.loc[row] for rep, row in [('1', 'D'),
@@ -121,8 +149,9 @@ def _parse_BloomLab_TecanPlate(*,
         # compute fraction infectivity for each replicate
         data = {rep: (repval - virus_only) / (no_serum - virus_only)
                 for rep, repval in reps.items()}
-        data['concentration'] = [initial_concentration / dilution_factor**i
-                                 for i in range(len(cols) - 1, -1, -1)]
+        data['concentration'] = [initial_concentration /
+                                 dilution_factor**(ncols - col)
+                                 for col in retained_cols]
         df = (pd.DataFrame(data)
               .melt(id_vars='concentration',
                     var_name='replicate',


### PR DESCRIPTION
Makes it possible to exclude specific columns in the Rachel-style 2019 assays.

This is useful as sometimes a single column in the plate has obvious problems (e.g., edge effects of autofluorescence from high serum concentration).