### PR TITLE
more robust curve fitting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,7 @@ cache: pip
 # temporarily pin pydocstyle for reason here:
 # https://gitlab.com/pycqa/flake8-docstrings/issues/36
 install:
-  - >
-     pip install
-     flake8
-     flake8-docstrings
-     flake8-rst-docstrings
-     flake8-builtins
-     flake8-import-order
-     flake8-comprehensions
-     flake8-bugbear
-     pydocstyle<4
+  - pip install -r test_requirements.txt
   - pip install -e .
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
      flake8-import-order
      flake8-comprehensions
      flake8-bugbear
+     pydocstyle<4  # https://gitlab.com/pycqa/flake8-docstrings/issues/36
   - pip install -e .
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 
 cache: pip
 
+# temporarily pin pydocstyle for reason here:
+# https://gitlab.com/pycqa/flake8-docstrings/issues/36
 install:
   - >
      pip install
@@ -15,7 +17,7 @@ install:
      flake8-import-order
      flake8-comprehensions
      flake8-bugbear
-     pydocstyle<4  # https://gitlab.com/pycqa/flake8-docstrings/issues/36
+     pydocstyle<4
   - pip install -e .
 
 script: 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.2.5
+-----
+
+Fixed
++++++
+- Better fit curves that never reach IC50.
+
 0.2.4
 -------
 

--- a/docs/curvefits_example.rst
+++ b/docs/curvefits_example.rst
@@ -478,3 +478,52 @@ Note that in doing this below, we use the colors and markers defined by
     ...                  },
     ...                 xlabel='concentration (ug/ml)',
     ...                 )
+
+Fitting some problematic curves
+--------------------------------
+Here we demonstrate that the method can also fit a problematic HIV curve
+that never reaches the IC50.
+
+Data frame with data for virus not neutralized at any concentration:
+
+.. nbplot::
+
+    >>> hiv_neut_data = pd.concat([
+    ...     pd.DataFrame({'serum': 'BF520.1',
+    ...                   'virus': 'H330R',
+    ...                   'replicate': 1,
+    ...                   'concentration' : [0.020576132, 0.061728395,
+    ...                                      0.185185185, 0.555555556,
+    ...                                      1.666666667, 5],
+    ...                    'fraction infectivity': [0.721440083, 0.882537173,
+    ...                                             1.01964302, 0.904916836,
+    ...                                             0.870465533, 0.866026089]}),
+    ...     pd.DataFrame({'serum': 'BF520.1',
+    ...                   'virus': 'H330R',
+    ...                   'replicate': 2,
+    ...                   'concentration' : [0.020576132, 0.061728395,
+    ...                                      0.185185185, 0.555555556,
+    ...                                      1.666666667, 5],
+    ...                    'fraction infectivity': [0.857961054, 0.973908617,
+    ...                                             1.04569174, 1.007668321,
+    ...                                             0.959208349, 1.046646303]})])
+    >>> hiv_neut_data.head()
+         serum  virus  replicate  concentration  fraction infectivity
+    0  BF520.1  H330R          1         0.0206                 0.721
+    1  BF520.1  H330R          1         0.0617                 0.883
+    2  BF520.1  H330R          1          0.185                  1.02
+    3  BF520.1  H330R          1          0.556                 0.905
+    4  BF520.1  H330R          1           1.67                  0.87
+
+Fit and plot curve:
+
+.. nbplot::
+
+    >>> hiv_fit = neutcurve.CurveFits(hiv_neut_data)
+    >>> _ = hiv_fit.plotSera(xlabel='concentration (ug/ml)')
+
+.. nbplot::
+
+    >>> hiv_fit.fitParams()
+         serum  virus replicate  nreplicates  ic50 ic50_bound ic50_str  midpoint  slope  top  bottom
+    0  BF520.1  H330R   average            2     5      lower       >5       123   23.1    1       0

--- a/neutcurve/__init__.py
+++ b/neutcurve/__init__.py
@@ -16,7 +16,7 @@ and classes into the package namespace:
 
 __author__ = 'Jesse Bloom'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.2.4'
+__version__ = '0.3.dev0'
 __url__ = 'https://github.com/jbloomlab/neutcurve'
 
 from neutcurve.curvefits import CurveFits  # noqa: F401

--- a/neutcurve/__init__.py
+++ b/neutcurve/__init__.py
@@ -16,7 +16,7 @@ and classes into the package namespace:
 
 __author__ = 'Jesse Bloom'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.3.dev0'
+__version__ = '0.2.5'
 __url__ = 'https://github.com/jbloomlab/neutcurve'
 
 from neutcurve.curvefits import CurveFits  # noqa: F401

--- a/neutcurve/hillcurve.py
+++ b/neutcurve/hillcurve.py
@@ -254,7 +254,7 @@ class HillCurve:
                  fs_stderr=None,
                  fixbottom=0,
                  fixtop=1,
-                 fitlogc=True,
+                 fitlogc=False,
                  use_stderr_for_fit=False,
                  ):
         """See main class docstring."""
@@ -272,65 +272,76 @@ class HillCurve:
         if any(self.cs <= 0):
             raise ValueError('concentrations in `cs` must all be > 0')
 
+        fit_tup = self._fit_curve(fixtop=fixtop,
+                                  fixbottom=fixbottom,
+                                  fitlogc=fitlogc,
+                                  use_stderr_for_fit=use_stderr_for_fit,
+                                  )
+        for i, param in enumerate(['midpoint', 'slope', 'bottom', 'top']):
+            setattr(self, param, fit_tup[i])
+
+    def _fit_curve(self, *, fixtop, fixbottom, fitlogc, use_stderr_for_fit):
+        """Fit and return `(midpoint, slope, bottom, top)`."""
         # make initial guess for slope to have the right sign
-        self.slope = 1.5
+        slope = 1.5
 
         # make initial guess for top and bottom
         if fixtop is False:
-            self.top = max(1, self.fs.max())
+            top = max(1, self.fs.max())
         else:
             if not isinstance(fixtop, (int, float)):
                 raise ValueError('`fixtop` is not `False` or a number')
-            self.top = fixtop
+            top = fixtop
         if fixbottom is False:
-            self.bottom = min(0, self.fs.min())
+            bottom = min(0, self.fs.min())
         else:
             if not isinstance(fixbottom, (int, float)):
                 raise ValueError('`fixbottom` is not `False` or a number')
-            self.bottom = fixbottom
+            bottom = fixbottom
 
         # make initial guess for midpoint
-        midval = (self.top - self.bottom) / 2.0
+        midval = (top - bottom) / 2.0
         if (self.fs > midval).all():
-            self.midpoint = self.cs[-1]
+            # guess above midpoint by amount equal to spacing of last 1 points
+            midpoint = self.cs[-1]**2 / self.cs[-2]
         elif (self.fs <= midval).all():
-            self.midpoint = self.cs[0]
+            # guess below midpoint by amount equal to spacing of last 1 points
+            midpoint = self.cs[0] / (self.cs[-1] / self.cs[-2])
         else:
             # get first index where f crosses midpoint
             i = scipy.argmax((self.fs > midval)[:-1] !=
                              (self.fs > midval)[1:])
             assert (self.fs[i] > midval) != (self.fs[i + 1] > midval)
-            self.midpoint = (self.cs[i] + self.cs[i + 1]) / 2.0
+            midpoint = (self.cs[i] + self.cs[i + 1]) / 2.0
 
         # set up function and initial guesses
         if fitlogc:
             evalfunc = self._evaluate_log
             xdata = scipy.log(self.cs)
-            self.midpoint = scipy.log(self.midpoint)
+            midpoint = scipy.log(midpoint)
         else:
             evalfunc = self.evaluate
             xdata = self.cs
+
         if fixtop is False and fixbottom is False:
-            func_vars = ['midpoint', 'slope', 'bottom', 'top']
+            initguess = [midpoint, slope, bottom, top]
             func = evalfunc
         elif fixtop is False:
-            func_vars = ['midpoint', 'slope', 'top']
+            initguess = [midpoint, slope, top]
 
             def func(c, m, s, t):
-                return evalfunc(c, m, s, self.bottom, t)
+                return evalfunc(c, m, s, bottom, t)
 
         elif fixbottom is False:
-            func_vars = ['midpoint', 'slope', 'bottom']
+            initguess = [midpoint, slope, bottom]
 
             def func(c, m, s, b):
-                return evalfunc(c, m, s, b, self.top)
+                return evalfunc(c, m, s, b, top)
         else:
-            func_vars = ['midpoint', 'slope']
+            initguess = [midpoint, slope]
 
             def func(c, m, s):
-                return evalfunc(c, m, s, self.bottom, self.top)
-
-        initguess = [getattr(self, varname) for varname in func_vars]
+                return evalfunc(c, m, s, bottom, top)
 
         (popt, pcov) = scipy.optimize.curve_fit(
                 f=func,
@@ -342,10 +353,20 @@ class HillCurve:
                 maxfev=1000,
                 )
 
-        for i, varname in enumerate(func_vars):
-            setattr(self, varname, popt[i])
         if fitlogc:
-            self.midpoint = scipy.exp(self.midpoint)
+            midpoint = scipy.exp(midpoint)
+
+        midpoint = popt[0]
+        slope = popt[1]
+        if fixbottom is False and fixtop is False:
+            bottom = popt[2]
+            top = popt[3]
+        elif fixbottom is False:
+            bottom = popt[2]
+        elif fixtop is False:
+            top = popt[2]
+
+        return (midpoint, slope, bottom, top)
 
     def icXX(self, fracneut, *, method='interpolate'):
         """Generalizes :meth:`HillCurve.ic50` to arbitrary frac neutralized.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,8 @@
+flake8
+flake8-docstrings
+flake8-rst-docstrings
+flake8-builtins
+flake8-import-order
+flake8-comprehensions
+flake8-bugbear
+pydocstyle<4


### PR DESCRIPTION
Previously the fitting sometimes does not converge, particularly when the the IC50 is outside the data range. This resulted in a `RuntimeError` from `scipy.optimize.curve_fit`. 

Now the code has been re-factored to first try the curve fitting with `scipy.optimize.curve_fit`, and then if that fails try with `scipy.minimize` (including bounds on key parameters).

In practice, this seems to have fixed the issue with the problematic HIV curves in this issue:
https://github.com/jbloomlab/neutcurve/issues/12

The reason why some optimizers work better on some curves then others it not clear, however.