### PR TITLE
only import `dmslogo` as needed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.5.5
+------
+
+Fixed
++++++
+- Only import ``dmslogo`` as needed.
+
 0.5.4
 -----
 

--- a/neutcurve/__init__.py
+++ b/neutcurve/__init__.py
@@ -16,7 +16,7 @@ and classes into the package namespace:
 
 __author__ = 'Jesse Bloom'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.5.4'
+__version__ = '0.5.5'
 __url__ = 'https://github.com/jbloomlab/neutcurve'
 
 from neutcurve.curvefits import CurveFits  # noqa: F401

--- a/neutcurve/curvefits.py
+++ b/neutcurve/curvefits.py
@@ -9,9 +9,6 @@ import collections
 import itertools
 import math
 
-import dmslogo.facet
-import dmslogo.utils
-
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 
@@ -1065,6 +1062,7 @@ class CurveFits:
                                              xextent * extend_lim)
 
         if align_to_dmslogo_facet:
+            import dmslogo.facet
             hparams = dmslogo.facet.height_params(
                                 nrows,
                                 align_to_dmslogo_facet['height_per_ax'],
@@ -1140,6 +1138,7 @@ class CurveFits:
             ax.tick_params('both', labelsize=ticksize, bottom=True, left=True,
                            right=False, top=False)
             if despine:
+                import dmslogo.utils
                 dmslogo.utils.despine(ax=ax)
             if vlines and ((irow, icol) in vlines):
                 for vline in vlines[(irow, icol)]:


### PR DESCRIPTION
Should fix #21, #25, #26, and #30 by only importing `dmslogo` when needed, which is rarely.