### PR TITLE
code and example on IC50 error estimates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
-0.6.0
+0.5.7
 ------
 
 Added

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.6.0
+------
+
+Added
++++++
+- Return standard errors on fit parameters.
+
 0.5.6
 ------
 

--- a/docs/curvefits_example.rst
+++ b/docs/curvefits_example.rst
@@ -290,7 +290,7 @@ Note that although this method is implemented, we **strongly** recommend instead
     10  H17-L19        WT   average            3  0.107  interpolated    0.107       0.144     0.107   3.94    1       0
     11  H17-L19     V135T   average            3   11.4         lower    >11.4         nan      15.5   2.76    1       0
 
-Here is the recommended way to get error estimaaets by just taking the average of fits for each replicate:
+Here is the recommended way to get error estimates by just taking the average of fits for each replicate:
 
 .. nbplot::
 

--- a/docs/curvefits_example.rst
+++ b/docs/curvefits_example.rst
@@ -270,6 +270,56 @@ For instance:
     10  H17-L19        WT   average            3  0.107  interpolated    0.107  0.227  interpolated    0.227     0.107   3.94    1       0
     11  H17-L19     V135T   average            3   11.4         lower    >11.4   11.4         lower    >11.4      15.5   2.76    1       0
 
+Include standard deviations on IC50s calculated from estimated errors on parameters during fitting.
+Note that although this method is implemented, we **strongly** recommend instead fitting each replicate separately and computing errors that way instead (see immediately below):
+
+.. nbplot::
+
+    >>> fits.fitParams(ic50_error='fit_stdev')
+          serum     virus replicate  nreplicates   ic50    ic50_bound ic50_str  ic50_error  midpoint  slope  top  bottom
+    0     FI6v3        WT   average            3  0.017  interpolated    0.017      0.0254     0.017   2.28    1       0
+    1     FI6v3    K(-8T)   average            3 0.0283  interpolated   0.0283      0.0411    0.0283    2.4    1       0
+    2     FI6v3      P80D   average            3 0.0123  interpolated   0.0123      0.0193    0.0123   2.05    1       0
+    3     FI6v3     V135T   average            3 0.0229  interpolated   0.0229      0.0382    0.0229   1.83    1       0
+    4     FI6v3     K280A   average            3 0.0106  interpolated   0.0106      0.0176    0.0106   1.86    1       0
+    5     FI6v3     K280S   average            3 0.0428  interpolated   0.0428      0.0683    0.0428      2    1       0
+    6     FI6v3     K280T   average            3 0.0348  interpolated   0.0348      0.0582    0.0348   1.82    1       0
+    7     FI6v3     N291S   average            3 0.0845  interpolated   0.0845       0.142    0.0845    1.8    1       0
+    8     FI6v3  M17L-HA2   average            3 0.0198  interpolated   0.0198      0.0313    0.0198   2.06    1       0
+    9     FI6v3  G47R-HA2   average            3 0.0348  interpolated   0.0348      0.0477    0.0348    2.6    1       0
+    10  H17-L19        WT   average            3  0.107  interpolated    0.107       0.144     0.107   3.94    1       0
+    11  H17-L19     V135T   average            3   11.4         lower    >11.4         nan      15.5   2.76    1       0
+
+Here is the recommended way to get error estimaaets by just taking the average of fits for each replicate:
+
+.. nbplot::
+
+   >>> params_avg_fit = fits.fitParams()[['serum', 'virus', 'ic50', 'ic50_bound',
+   ...                                    'nreplicates']]
+   >>> params_avg_reps = (
+   ...     fits.fitParams(average_only=False)
+   ...     .query('replicate != "average"')
+   ...     .groupby(['serum', 'virus'])
+   ...     .aggregate(ic50_replicate_avg=pd.NamedAgg('ic50', 'mean'),
+   ...                ic50_replicate_stderr=pd.NamedAgg('ic50', 'sem'),
+   ...                )
+   ...     .reset_index()
+   ...     )
+   >>> params_avg_fit.merge(params_avg_reps, on=['serum', 'virus'])
+         serum     virus   ic50    ic50_bound  nreplicates  ic50_replicate_avg  ic50_replicate_stderr
+   0     FI6v3        WT  0.017  interpolated            3               0.017                0.00112
+   1     FI6v3    K(-8T) 0.0283  interpolated            3              0.0283                 0.0015
+   2     FI6v3      P80D 0.0123  interpolated            3              0.0123               0.000271
+   3     FI6v3     V135T 0.0229  interpolated            3              0.0229               0.000201
+   4     FI6v3     K280A 0.0106  interpolated            3              0.0106               0.000819
+   5     FI6v3     K280S 0.0428  interpolated            3              0.0428               0.000821
+   6     FI6v3     K280T 0.0348  interpolated            3              0.0349                0.00155
+   7     FI6v3     N291S 0.0845  interpolated            3              0.0844                0.00448
+   8     FI6v3  M17L-HA2 0.0198  interpolated            3              0.0197               0.000986
+   9     FI6v3  G47R-HA2 0.0348  interpolated            3              0.0347               0.000766
+   10  H17-L19        WT  0.107  interpolated            3               0.108                0.00698
+   11  H17-L19     V135T   11.4         lower            3                11.4                      0
+
 Plotting the curves
 -------------------
 

--- a/neutcurve/__init__.py
+++ b/neutcurve/__init__.py
@@ -16,7 +16,7 @@ and classes into the package namespace:
 
 __author__ = 'Jesse Bloom'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.6.0'
+__version__ = '0.5.7'
 __url__ = 'https://github.com/jbloomlab/neutcurve'
 
 from neutcurve.curvefits import CurveFits  # noqa: F401

--- a/neutcurve/__init__.py
+++ b/neutcurve/__init__.py
@@ -16,7 +16,7 @@ and classes into the package namespace:
 
 __author__ = 'Jesse Bloom'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.5.6'
+__version__ = '0.6.0'
 __url__ = 'https://github.com/jbloomlab/neutcurve'
 
 from neutcurve.curvefits import CurveFits  # noqa: F401

--- a/neutcurve/hillcurve.py
+++ b/neutcurve/hillcurve.py
@@ -91,7 +91,9 @@ class HillCurve:
         `params_stdev` (dict or `None`)
             If standard deviations can be estimated on the fit
             parameters, keyed by 'bottom', 'top', 'midpoint',
-            and 'slope' and gives standard eerrorr on each.
+            and 'slope' and gives standard erorr on each. Note if
+            you have replicates we recommend fitting those separately
+            and taking standard error rather than using fit stdev.
 
     Use the :meth:`ic50` method to get the fitted IC50.
     You can use :meth:`ic50_stdev` to get the estimated standard
@@ -663,9 +665,12 @@ class HillCurve:
         return self.icXX(0.5, method=method)
 
     def ic50_stdev(self):
-        r"""Get standard deviation of estimated IC50.
+        r"""Get standard deviation of fit IC50 parameter.
 
         Calculated just from estimated standard deviation on `midpoint`.
+        Note if you have replicates, we recommend fitting separately
+        and calculating standard error from those fits rather than
+        using this value.
 
         Returns:
             A number giving the standard deviation, or `None` if cannot

--- a/neutcurve/hillcurve.py
+++ b/neutcurve/hillcurve.py
@@ -88,8 +88,16 @@ class HillCurve:
             if :math:`t \ne 1` or :math:`b \ne 0`.
         `slope` (float)
             Hill slope of curve, :math:`s` in equation above.
+        `params_stdev` (dict or `None`)
+            If standard deviations can be estimated on the fit
+            parameters, keyed by 'bottom', 'top', 'midpoint',
+            and 'slope' and gives standard eerrorr on each.
 
     Use the :meth:`ic50` method to get the fitted IC50.
+    You can use :meth:`ic50_stdev` to get the estimated standard
+    deviation on the IC50, although if you have multiple replicates
+    you may be better off just fitting to each separately and
+    then taking standard error of the individual IC50s.
 
     Here are some examples. First, we import the necessary modules:
 
@@ -125,6 +133,14 @@ class HillCurve:
         True
         >>> numpy.allclose(neut.bottom, b)
         True
+        >>> for key, val in neut.params_stdev.items():
+        ...     print(f"{key} = {val:.2g}")
+        midpoint = 0.062
+        slope = 6.3
+        top = 0
+        bottom = 0.73
+        >>> print(f"IC50: {neut.ic50():.3f} +/- {neut.ic50_stdev():.3f}")
+        IC50: 0.034 +/- 0.070
 
     Since we fit the curve to simulated data where the bottom was
     0.1 rather than 0, the midpoint and IC50 are different. Specifically,
@@ -322,7 +338,8 @@ class HillCurve:
 
         # first try to fit using curve_fit
         try:
-            fit_tup = self._fit_curve(fixtop=fixtop,
+            fit_tup, self.params_stdev = self._fit_curve(
+                                      fixtop=fixtop,
                                       fixbottom=fixbottom,
                                       fitlogc=fitlogc,
                                       use_stderr_for_fit=use_stderr_for_fit)
@@ -336,6 +353,7 @@ class HillCurve:
                                     use_stderr_for_fit=use_stderr_for_fit,
                                     method=method,
                                     )
+                self.params_stdev = None  # can't estimate errors
                 if fit_tup is not False:
                     break
             else:
@@ -345,7 +363,7 @@ class HillCurve:
             setattr(self, param, fit_tup[i])
 
     def _fit_curve(self, *, fixtop, fixbottom, fitlogc, use_stderr_for_fit):
-        """Fit via curve_fit, and return `(midpoint, slope, bottom, top)`."""
+        """curve_fit, return `(midpoint, slope, bottom, top), params_stdev`."""
         # make initial guess for slope to have the right sign
         slope = 1.5
 
@@ -428,20 +446,30 @@ class HillCurve:
                 maxfev=1000,
                 )
 
+        perr = numpy.sqrt(numpy.diag(pcov))
+
         if fitlogc:
             midpoint = numpy.exp(midpoint)
 
         midpoint = popt[0]
         slope = popt[1]
+        params_stderr = {'midpoint': perr[0],
+                         'slope': perr[1],
+                         'top': 0,
+                         'bottom': 0}
         if fixbottom is False and fixtop is False:
             bottom = popt[2]
+            params_stderr['bottom'] = perr[2]
             top = popt[3]
+            params_stderr['top'] = perr[3]
         elif fixbottom is False:
             bottom = popt[2]
+            params_stderr['bottom'] = perr[2]
         elif fixtop is False:
             top = popt[2]
+            params_stderr['top'] = perr[2]
 
-        return (midpoint, slope, bottom, top)
+        return (midpoint, slope, bottom, top), params_stderr
 
     def _minimize_fit(self, *, fixtop, fixbottom, fitlogc, use_stderr_for_fit,
                       method):
@@ -633,6 +661,25 @@ class HillCurve:
 
         """
         return self.icXX(0.5, method=method)
+
+    def ic50_stdev(self):
+        r"""Get standard deviation of estimated IC50.
+
+        Calculated just from estimated standard deviation on `midpoint`.
+
+        Returns:
+            A number giving the standard deviation, or `None` if cannot
+            be estimated or if IC50 is at bound.
+
+        """
+        ic50 = self.ic50()
+        if ic50 is None:
+            return None
+        midpoint_stdev = self.params_stdev['midpoint']
+        if midpoint_stdev is None:
+            return None
+        else:
+            return midpoint_stdev * ic50 / self.midpoint
 
     def icXX_bound(self, fracneut):
         """Like :meth:`HillCurve.ic50_bound` for arbitrary frac neutralized."""


### PR DESCRIPTION
Add code to estimate standard deviation on fit parameters as a measure of error, and document.

However, also noted this appears inferior to just fitting replicates separately and calculating standard error from that, so added example for how to do that and made clear it is the recommended approach rather than using the fit parameters.

@ajgreaney, this is documented at the bottom of this section of the docs: https://jbloomlab.github.io/neutcurve/curvefits_example.html#accessing-the-fit-parameters-for-all-curves 

This is version 0.5.7.