### PR TITLE
add `CurveFits.combineCurveFits` method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.9.0
+-----
+
+Added
++++++
+- Added the ``CurveFits.combineCurveFits`` static method to combine multiple ``CurveFits`` objects.
+
 0.8.0
 -----
 

--- a/docs/combine_curvefits.nblink
+++ b/docs/combine_curvefits.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../notebooks/combine_curvefits.ipynb"
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents
    installation
    hillcurve_example
    curvefits_example
+   combine_curvefits
    neutcurve
    package_index
    acknowledgments

--- a/neutcurve/__init__.py
+++ b/neutcurve/__init__.py
@@ -16,7 +16,7 @@ and classes into the package namespace:
 
 __author__ = "Jesse Bloom"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 __url__ = "https://github.com/jbloomlab/neutcurve"
 
 from neutcurve.curvefits import CurveFits  # noqa: F401

--- a/neutcurve/curvefits.py
+++ b/neutcurve/curvefits.py
@@ -67,6 +67,21 @@ class CurveFits:
     # names commonly used for wildtype virus
     _WILDTYPE_NAMES = ("WT", "wt", "wildtype", "Wildtype", "wild type", "Wild type")
 
+    @staticmethod
+    def combineCurveFits(curvefits_list):
+        """
+        Args:
+            `curvesfit_list` (list)
+                List of :class:`CurveFits` objects that are identical other than the
+                data they contain and have unique virus/serum/replicate combinations.
+
+        Returns:
+            combined_fits (:class:`CurveFits`)
+                A `:class:`CurveFits` objec that combines all the virus/serum/replicate
+                combinations in `curvefits_list`.
+        """
+        raise NotImplementedError
+
     def __init__(
         self,
         data,

--- a/notebooks/combine_curvefits.ipynb
+++ b/notebooks/combine_curvefits.ipynb
@@ -1,0 +1,258 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Combining `CurveFits` objects\n",
+    "\n",
+    "We can also combine together `CurveFits` objects for distinct serum/viruses/replicates using the `CurveFits.combineCurveFits` method.\n",
+    "This is useful if you are fitting large datasets in chunks, and then want to combine all the results.\n",
+    "\n",
+    "Here is an example/test:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-12-13T04:24:38.393504Z",
+     "iopub.status.busy": "2023-12-13T04:24:38.392651Z",
+     "iopub.status.idle": "2023-12-13T04:24:40.233700Z",
+     "shell.execute_reply": "2023-12-13T04:24:40.232271Z",
+     "shell.execute_reply.started": "2023-12-13T04:24:38.393466Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "import neutcurve"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read in the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-12-13T04:24:40.242761Z",
+     "iopub.status.busy": "2023-12-13T04:24:40.242066Z",
+     "iopub.status.idle": "2023-12-13T04:24:40.251031Z",
+     "shell.execute_reply": "2023-12-13T04:24:40.250248Z",
+     "shell.execute_reply.started": "2023-12-13T04:24:40.242729Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fi6v3_datafile = \"Doud_et_al_2018-neutdata.csv\"\n",
+    "data = pd.read_csv(fi6v3_datafile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a `CurveFits` object with all the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-12-13T04:24:40.255392Z",
+     "iopub.status.busy": "2023-12-13T04:24:40.255064Z",
+     "iopub.status.idle": "2023-12-13T04:24:40.556528Z",
+     "shell.execute_reply": "2023-12-13T04:24:40.555779Z",
+     "shell.execute_reply.started": "2023-12-13T04:24:40.255368Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jbloom/neutcurve/neutcurve/hillcurve.py:738: RuntimeWarning: invalid value encountered in power\n",
+      "  return b + (t - b) / (1 + (c / m) ** s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "fits = neutcurve.CurveFits(data)\n",
+    "_ = fits.fitParams(average_only=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now split the data to make different `CurveFits` which we can combine:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-12-13T04:24:40.560854Z",
+     "iopub.status.busy": "2023-12-13T04:24:40.560533Z",
+     "iopub.status.idle": "2023-12-13T04:24:41.092707Z",
+     "shell.execute_reply": "2023-12-13T04:24:41.091945Z",
+     "shell.execute_reply.started": "2023-12-13T04:24:40.560831Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jbloom/neutcurve/neutcurve/hillcurve.py:738: RuntimeWarning: invalid value encountered in power\n",
+      "  return b + (t - b) / (1 + (c / m) ** s)\n",
+      "/home/jbloom/neutcurve/neutcurve/hillcurve.py:738: RuntimeWarning: invalid value encountered in power\n",
+      "  return b + (t - b) / (1 + (c / m) ** s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# split the data in half\n",
+    "data1 = data[(data[\"replicate\"] == 1) | (data[\"serum\"] == \"H17-L19\")]\n",
+    "data2 = data[(data[\"replicate\"] != 1) & (data[\"serum\"] != \"H17-L19\")]\n",
+    "\n",
+    "# make a second split that is **not** disjoint from the first one\n",
+    "data2_invalid = data[data[\"replicate\"] != 1]\n",
+    "\n",
+    "# make fits to each of these\n",
+    "fit1 = neutcurve.CurveFits(data1)\n",
+    "_ = fit1.fitParams(average_only=False)\n",
+    "fit2 = neutcurve.CurveFits(data2)\n",
+    "_ = fit2.fitParams(average_only=False)\n",
+    "fit2_invalid = neutcurve.CurveFits(data2_invalid)\n",
+    "_ = fit2_invalid.fitParams(average_only=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Combine two fits using `CurveFits.combineCurveFits` that should yield an object the same as `fits`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-12-13T04:24:41.097074Z",
+     "iopub.status.busy": "2023-12-13T04:24:41.096829Z",
+     "iopub.status.idle": "2023-12-13T04:24:41.175799Z",
+     "shell.execute_reply": "2023-12-13T04:24:41.174999Z",
+     "shell.execute_reply.started": "2023-12-13T04:24:41.097051Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jbloom/neutcurve/neutcurve/hillcurve.py:738: RuntimeWarning: invalid value encountered in power\n",
+      "  return b + (t - b) / (1 + (c / m) ** s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "combined_fits = neutcurve.CurveFits.combineCurveFits([fit1, fit2])\n",
+    "\n",
+    "pd.testing.assert_frame_equal(\n",
+    "    fits.fitParams(average_only=False),\n",
+    "    combined_fits.fitParams(average_only=False),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-12-13T04:11:10.937777Z",
+     "iopub.status.busy": "2023-12-13T04:11:10.937151Z",
+     "iopub.status.idle": "2023-12-13T04:11:10.955279Z",
+     "shell.execute_reply": "2023-12-13T04:11:10.954532Z",
+     "shell.execute_reply.started": "2023-12-13T04:11:10.937726Z"
+    }
+   },
+   "source": [
+    "Make sure we cannot combine two fits with overlapping entries, this should give an error due to shared serum/virus/replicates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-12-13T04:24:41.179493Z",
+     "iopub.status.busy": "2023-12-13T04:24:41.179178Z",
+     "iopub.status.idle": "2023-12-13T04:24:41.804570Z",
+     "shell.execute_reply": "2023-12-13T04:24:41.803184Z",
+     "shell.execute_reply.started": "2023-12-13T04:24:41.179468Z"
+    }
+   },
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "duplicated sera/virus/replicate in `curvefits_list`",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[6], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# NBVAL_RAISES_EXCEPTION\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m \u001b[43mneutcurve\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mCurveFits\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcombineCurveFits\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[43mfit1\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfit2_invalid\u001b[49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/neutcurve/neutcurve/curvefits.py:161\u001b[0m, in \u001b[0;36mCurveFits.combineCurveFits\u001b[0;34m(curvefits_list)\u001b[0m\n\u001b[1;32m    150\u001b[0m combined_fits\u001b[38;5;241m.\u001b[39mdf \u001b[38;5;241m=\u001b[39m combined_fits\u001b[38;5;241m.\u001b[39m_get_avg_and_stderr_df(combined_fits\u001b[38;5;241m.\u001b[39mdf)\n\u001b[1;32m    151\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(combined_fits\u001b[38;5;241m.\u001b[39mdf) \u001b[38;5;241m!=\u001b[39m \u001b[38;5;28mlen\u001b[39m(\n\u001b[1;32m    152\u001b[0m     combined_fits\u001b[38;5;241m.\u001b[39mdf\u001b[38;5;241m.\u001b[39mgroupby(\n\u001b[1;32m    153\u001b[0m         [\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    159\u001b[0m     )\n\u001b[1;32m    160\u001b[0m ):\n\u001b[0;32m--> 161\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mduplicated sera/virus/replicate in `curvefits_list`\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    163\u001b[0m \u001b[38;5;66;03m# combine sera\u001b[39;00m\n\u001b[1;32m    164\u001b[0m combined_fits\u001b[38;5;241m.\u001b[39msera \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlist\u001b[39m(\n\u001b[1;32m    165\u001b[0m     \u001b[38;5;28mdict\u001b[39m\u001b[38;5;241m.\u001b[39mfromkeys([serum \u001b[38;5;28;01mfor\u001b[39;00m f \u001b[38;5;129;01min\u001b[39;00m curvefits_list \u001b[38;5;28;01mfor\u001b[39;00m serum \u001b[38;5;129;01min\u001b[39;00m f\u001b[38;5;241m.\u001b[39msera])\n\u001b[1;32m    166\u001b[0m )\n",
+      "\u001b[0;31mValueError\u001b[0m: duplicated sera/virus/replicate in `curvefits_list`"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_RAISES_EXCEPTION\n",
+    "\n",
+    "neutcurve.CurveFits.combineCurveFits([fit1, fit2_invalid])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Allows combining multiple `CurveFits` objects generated by a pipeline.

Becomes version 0.9.0.