### PR TITLE
`CurveFits.plotReplicates` no longer fails if too many replicates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+1.1.2
+-----
+
+Fixed
++++++
+- ``CurveFits.plotReplicates`` no longer fails if too many replicates, but instead recycles colors and markers. To make these combinations unique by default, also added another marker to ``CBMARKERS``.
+
 1.1.1
 -----
 

--- a/neutcurve/__init__.py
+++ b/neutcurve/__init__.py
@@ -16,7 +16,7 @@ and classes into the package namespace:
 
 __author__ = "Jesse Bloom"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 __url__ = "https://github.com/jbloomlab/neutcurve"
 
 from neutcurve.curvefits import CurveFits  # noqa: F401

--- a/neutcurve/colorschemes.py
+++ b/neutcurve/colorschemes.py
@@ -32,10 +32,9 @@ CBBPALETTE = (
     "#CC79A7",
 )
 
-#: list of matplotlib markers same length as `CBPALETTE`, from
+#: list of matplotlib markers, from
 #: https://matplotlib.org/api/markers_api.html
-CBMARKERS = ("o", "^", "s", "D", "v", "<", ">", "p")
-assert len(CBPALETTE) == len(CBBPALETTE) == len(CBMARKERS)
+CBMARKERS = ("o", "^", "s", "D", "v", "<", ">", "p", "x")
 
 if __name__ == "__main__":
     import doctest

--- a/neutcurve/curvefits.py
+++ b/neutcurve/curvefits.py
@@ -1094,10 +1094,8 @@ class CurveFits:
         sera, viruses = self._sera_viruses_lists(sera, viruses)
 
         # get replicates and make sure there aren't too many
-        nplottable = max(len(colors), len(markers))
         if average_only:
             replicates = ["average"]
-            nreplicates = 1
         elif attempt_shared_legend:
             replicates = collections.OrderedDict()
             if show_average:
@@ -1108,7 +1106,6 @@ class CurveFits:
                         if replicate != "average":
                             replicates[replicate] = True
             replicates = list(collections.OrderedDict(replicates).keys())
-            nreplicates = len(replicates)
         else:
             replicates_by_serum_virus = collections.defaultdict(list)
             for serum, virus in itertools.product(sera, viruses):
@@ -1120,13 +1117,6 @@ class CurveFits:
                     for replicate in self.replicates[(serum, virus)]:
                         if replicate != "average":
                             replicates_by_serum_virus[key].append(replicate)
-            nreplicates = max(len(reps) for reps in replicates_by_serum_virus.values())
-        if nreplicates > nplottable:
-            raise ValueError(
-                f"Too many unique replicates. There are {nreplicates} on a single plot "
-                f"but only {nplottable} `colors` or `markers`. Either specify more "
-                "colors/markers, or try setting `attempt_shared_legend=False`"
-            )
 
         # build list of plots appropriate for `plotGrid`
         plotlist = []
@@ -1147,8 +1137,8 @@ class CurveFits:
                                 "virus": virus,
                                 "replicate": replicate,
                                 "label": {False: replicate, True: None}[average_only],
-                                "color": colors[i],
-                                "marker": markers[i],
+                                "color": colors[i % len(colors)],
+                                "marker": markers[i % len(markers)],
                             }
                         )
                 if curvelist:


### PR DESCRIPTION
Instead recycles colors and markers. To make these combinations unique by default, also added another marker to `CBMARKERS`.