### PR TITLE
fix `CurveFit.fitParams` in edge case w no curves

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+2.0.1
+-----
+
+Fixed
++++++
+- Don't throw an uninterprtable error if ``CurveFits.fitParams`` called with no curves, instead just return empty data frame.
+
 2.0.0
 -----
+
+Added
++++++
 - The curve fitting parameters (top, bottom, slope) can now be constrained to a range in addition to being completely free or fixed. This can help with fitting some curves more sensibly (see [this issue](https://github.com/jbloomlab/neutcurve/issues/53)). Specifically:
   - ``fixtop`` and ``fixbottom`` parameters to ``HillCurve`` can be 2-tuples of bounds
   - added ``fixslope`` parameter to ``HillCurve`` and ``CurveFits``

--- a/neutcurve/__init__.py
+++ b/neutcurve/__init__.py
@@ -16,7 +16,7 @@ and classes into the package namespace:
 
 __author__ = "Jesse Bloom"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __url__ = "https://github.com/jbloomlab/neutcurve"
 
 from neutcurve.curvefits import CurveFits  # noqa: F401

--- a/neutcurve/curvefits.py
+++ b/neutcurve/curvefits.py
@@ -604,9 +604,16 @@ class CurveFits:
                 ic_cols += [prefix, f"{prefix}_bound", f"{prefix}_str"]
             if ic50_error == "fit_stdev":
                 ic_cols.append("ic50_error")
-            self._fitparams[key] = pd.DataFrame(d)[
-                ["serum", "virus", "replicate", "nreplicates"] + ic_cols + params
-            ].assign(nreplicates=lambda x: (x["nreplicates"].astype("Int64")))
+            if len(d):
+                self._fitparams[key] = pd.DataFrame(d)[
+                    ["serum", "virus", "replicate", "nreplicates"] + ic_cols + params
+                ].assign(nreplicates=lambda x: (x["nreplicates"].astype("Int64")))
+            else:
+                self._fitparams[key] = pd.DataFrame(
+                    columns=["serum", "virus", "replicate", "nreplicates"]
+                    + ic_cols
+                    + params,
+                )
 
         return self._fitparams[key]
 


### PR DESCRIPTION
Don't throw an uninterprtable error if ``CurveFits.fitParams`` called with no curves, instead just return empty data frame.