### PR TITLE
speed up plotting of large grids of curves

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+2.2.0
+-----
+
+Added
++++++
+- Fixes to speed up plotting of large grids of neutralization curves. Remove internal inefficiencies in code that were repeatedly re-setting shared axes. Also add the ``no_tight_layout`` option to ``CurveFits.plotGrid`` and reduced default ``npoints`` from 200 to 120 in ``HillCurve.concentrationRange``.
+
 2.1.0
 -----
 

--- a/neutcurve/__init__.py
+++ b/neutcurve/__init__.py
@@ -16,7 +16,7 @@ and classes into the package namespace:
 
 __author__ = "Jesse Bloom"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 __url__ = "https://github.com/jbloomlab/neutcurve"
 
 from neutcurve.curvefits import CurveFits  # noqa: F401

--- a/neutcurve/curvefits.py
+++ b/neutcurve/curvefits.py
@@ -1244,6 +1244,7 @@ class CurveFits:
         sharey=True,
         vlines=None,
         draw_in_bounds=False,
+        no_tight_layout=False,
     ):
         """Plot arbitrary grid of curves.
 
@@ -1321,6 +1322,8 @@ class CurveFits:
                 'color', and 'linestyle'.
             `draw_in_bounds` (bool)
                 Same meaning as for meth:`neutcurve.hillcurve.HillCurve.plot`.
+            `no_tight_layout` (bool)
+                Do not apply tight layout to plot (can make it faster).
 
         Returns:
             The 2-tuple `(fig, axes)` of matplotlib figure and 2D axes array.
@@ -1438,9 +1441,20 @@ class CurveFits:
             axes[irow, icol].set_xlim(
                 lims[irow, icol]["xmin"], lims[irow, icol]["xmax"]
             )
+            if sharex:
+                # if doing sharex, should be only one value, set on one and it propagates
+                assert len(set(d["xmin"] for d in lims.values())) == 1
+                assert len(set(d["xmax"] for d in lims.values())) == 1
+                break
+        for irow, icol in plots.keys():
             axes[irow, icol].set_ylim(
                 lims[irow, icol]["ymin"], lims[irow, icol]["ymax"]
             )
+            if sharey:
+                # if doing sharey, should be only one value, set on one and it propagates
+                assert len(set(d["ymin"] for d in lims.values())) == 1
+                assert len(set(d["ymax"] for d in lims.values())) == 1
+                break  # if doing sharey, only need to set on one and it propagates
 
         # make plots
         shared_legend = attempt_shared_legend
@@ -1610,7 +1624,7 @@ class CurveFits:
                 left=align_to_dmslogo_facet["left"],
                 right=align_to_dmslogo_facet["right"],
             )
-        else:
+        elif not no_tight_layout:
             fig.tight_layout()
 
         return fig, axes

--- a/neutcurve/hillcurve.py
+++ b/neutcurve/hillcurve.py
@@ -1267,15 +1267,16 @@ class HillCurve:
         ax.errorbar(
             x="concentration",
             y="measurement",
-            yerr="stderr",
-            data=data,
+            yerr=None if (self.fs_stderr is None) else "stderr",
+            data=data[data["measurement"].notnull()],
             fmt=marker,
             color=color,
             markersize=markersize,
             capsize=markersize / 1.5,
         )
 
-        ax.set_xscale("log")
+        if ax.get_xscale() != "log":
+            ax.set_xscale("log")
         ax.set_xlabel(xlabel, fontsize=15)
         ax.set_ylabel(ylabel, fontsize=15)
         ax.tick_params("both", labelsize=12, length=5, width=1)
@@ -1349,7 +1350,7 @@ class HillCurve:
         )
 
 
-def concentrationRange(bottom, top, npoints=200, extend=0.1):
+def concentrationRange(bottom, top, npoints=120, extend=0.1):
     """Logarithmically spaced concentrations for plotting.
 
     Useful if you want to plot a curve by fitting values to densely


### PR DESCRIPTION
Remove internal inefficiencies in code that were repeatedly re-setting shared axes. Also add the ``no_tight_layout`` option to ``CurveFits.plotGrid`` and reduced default ``npoints`` from 200 to 120 in ``HillCurve.concentrationRange``.